### PR TITLE
Fix failing App test with router and MUI mocks

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,44 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
-test('renders learn react link', () => {
+// Mock react-router-dom to avoid pulling in the real implementation during tests
+jest.mock(
+  'react-router-dom',
+  () => ({
+    BrowserRouter: ({ children }) => <div>{children}</div>,
+    Routes: ({ children }) => <div>{children}</div>,
+    Route: ({ element }) => element,
+    Link: ({ children }) => <div>{children}</div>,
+  }),
+  { virtual: true },
+);
+
+// Stub out MUI components used by the application
+jest.mock(
+  '@mui/material',
+  () => ({
+    AppBar: ({ children }) => <div>{children}</div>,
+    Toolbar: ({ children }) => <div>{children}</div>,
+    Typography: ({ children }) => <div>{children}</div>,
+    Button: ({ children }) => <button>{children}</button>,
+    CssBaseline: ({ children }) => <div>{children}</div>,
+    Container: ({ children }) => <div>{children}</div>,
+    ThemeProvider: ({ children }) => <div>{children}</div>,
+    createTheme: () => ({}),
+  }),
+  { virtual: true },
+);
+
+// Mock page components to avoid importing their heavy dependencies
+jest.mock('./pages/MaterialsPage', () => () => <div>Materials</div>);
+jest.mock('./pages/ProjectsPage', () => () => <div>Projects</div>);
+jest.mock('./pages/TransactionsPage', () => () => <div>Transactions</div>);
+jest.mock('./pages/ReportsPage', () => () => <div>Reports</div>);
+
+// Import App after mocking react-router-dom
+const App = require('./App').default;
+
+test('renders application title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = screen.getByText(/ระบบจัดการวัสดุอุปกรณ์/i);
+  expect(titleElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- mock React Router, MUI, and page components in App test
- verify application title renders as expected

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_689c00f35308832c89d19a6e71f1091b